### PR TITLE
Fix duplicate repair action

### DIFF
--- a/Deploy-Alteryx.ps1
+++ b/Deploy-Alteryx.ps1
@@ -390,8 +390,8 @@ Process {
         "download"      { $Process = Invoke-DownloadAlteryx     -Properties $Properties -InstallationProperties $InstallationProperties -Unattended:$Unattended }
         "help"          { $Process = Show-Help                                                                                                                  }
         "install"       { $Process = Install-Alteryx            -Properties $Properties -InstallationProperties $InstallationProperties -Unattended:$Unattended }
-        "repair"        { $Process = Repair-Alteryx             -Properties $Properties -Unattended:$Unattended                                                 }
-        "open"          { $Process = Open-Alteryx               -Properties $Properties -Unattended:$Unattended                                                 }
+        "open"          { $Process = Open-Alteryx               -Properties $Properties -Unattended:$Unattended
+        }
         "patch"         { $Process = Invoke-PatchAlteryx        -Properties $Properties -Unattended:$Unattended                                                 }
         "ping"          { $Process = Invoke-PingAlteryx         -Properties $Properties -Unattended:$Unattended                                                 }
         "repair"        { $Process = Repair-Alteryx             -Properties $Properties -Unattended:$Unattended                                                 }

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This section lists the mandatory parameters that must be specified to run the sc
 
 The `Action` parameter corresponds to the operation to perform.
 
-Nineteen options are available:
+Twenty options are available:
 
 - activate:     activate the Alteryx application license
 - backup:       backup the Alteryx application database
@@ -183,7 +183,6 @@ Nineteen options are available:
 - download:     download latest Alteryx application release
 - help:         display the help documentation
 - install:      install the Alteryx application
-- repair:       repair the Alteryx application database
 - open:         open the Alteryx application
 - patch:        patch upgrade the Alteryx application
 - ping:         check the status of the Alteryx application


### PR DESCRIPTION
## Summary
- remove duplicate repair action from Deploy-Alteryx switch
- fix README list of actions

## Testing
- `pwsh` was not available to run PSScriptAnalyzer